### PR TITLE
Add report generator for monthly attendance excluding March

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,4 +1,15 @@
 # services/__init__.py
-from .report_service import ReportService
 
-__all__ = ['ReportService']
+__all__ = ['ReportService', 'generar_reporte_meses']
+
+
+def __getattr__(name):
+    if name == 'ReportService':
+        from .report_service import ReportService
+
+        return ReportService
+    if name == 'generar_reporte_meses':
+        from .report_service_meses import generar_reporte_meses
+
+        return generar_reporte_meses
+    raise AttributeError(f"module 'services' has no attribute {name!r}")

--- a/services/report_service_meses.py
+++ b/services/report_service_meses.py
@@ -1,0 +1,81 @@
+import os
+from datetime import datetime
+from typing import List
+
+import pandas as pd
+from sqlalchemy.orm import Session
+
+
+MESES_SIN_MARZO: List[str] = [
+    'enero', 'febrero', 'abril', 'mayo', 'junio',
+    'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'
+]
+
+
+def _obtener_registro_mas_reciente(registro_actual, registro_existente):
+    """Devuelve el registro con el updated_at más reciente."""
+    fecha_actual = getattr(registro_actual, 'updated_at', None) or datetime.min
+    fecha_existente = getattr(registro_existente, 'updated_at', None) or datetime.min
+    return registro_actual if fecha_actual >= fecha_existente else registro_existente
+
+
+def _get_report_service():
+    from .report_service import ReportService
+
+    return ReportService
+
+
+def generar_reporte_meses(db: Session, filename: str = "reporte_meses.xlsx") -> str:
+    """Genera un reporte en Excel con la cantidad de meses asistidos por adolescente excluyendo marzo."""
+    report_service = _get_report_service()
+    registros = report_service.get_vista_oferta_reconstruida(db)
+    registros_estado_dos = [r for r in registros if getattr(r, 'estado', None) == 2]
+
+    registros_por_adolescente = {}
+    for registro in registros_estado_dos:
+        existente = registros_por_adolescente.get(registro.id_adolescente)
+        if existente is None:
+            registros_por_adolescente[registro.id_adolescente] = registro
+        else:
+            registros_por_adolescente[registro.id_adolescente] = _obtener_registro_mas_reciente(
+                registro,
+                existente
+            )
+
+    registros_unicos = sorted(
+        registros_por_adolescente.values(),
+        key=lambda r: getattr(r, 'id_adolescente', 0)
+    )
+
+    detalle_rows = []
+    for registro in registros_unicos:
+        meses_asistidos = [mes for mes in MESES_SIN_MARZO if getattr(registro, mes, 0) == 1]
+        detalle_rows.append({
+            'id_adolescente': getattr(registro, 'id_adolescente', None),
+            'Nombre': getattr(registro, 'Nombre', ''),
+            'Apellido': getattr(registro, 'Apellido', ''),
+            'DNI': getattr(registro, 'DNI', ''),
+            'Sede': getattr(registro, 'Sede', ''),
+            'Actividad': getattr(registro, 'Actividad', ''),
+            'cantidad_meses_sin_marzo': len(meses_asistidos),
+            'meses_asistidos_sin_marzo': ' - '.join(meses_asistidos)
+        })
+
+    df_detalle = pd.DataFrame(detalle_rows)
+
+    if not df_detalle.empty:
+        frecuencia_series = df_detalle['cantidad_meses_sin_marzo'].value_counts().sort_index()
+        df_frecuencia = frecuencia_series.reset_index()
+        df_frecuencia.columns = ['cantidad_meses_sin_marzo', 'frecuencia']
+    else:
+        df_frecuencia = pd.DataFrame(columns=['cantidad_meses_sin_marzo', 'frecuencia'])
+
+    documents_path = os.path.expanduser('~/Documents')
+    os.makedirs(documents_path, exist_ok=True)
+    full_path = os.path.join(documents_path, filename)
+
+    with pd.ExcelWriter(full_path, engine='openpyxl') as writer:
+        df_detalle.to_excel(writer, sheet_name='Meses_por_adolescente', index=False)
+        df_frecuencia.to_excel(writer, sheet_name='Frecuencia_por_meses', index=False)
+
+    return full_path

--- a/test_report_service_meses.py
+++ b/test_report_service_meses.py
@@ -1,0 +1,114 @@
+import os
+import tempfile
+import unittest
+from datetime import datetime
+from unittest.mock import patch
+
+import pandas as pd
+
+from services.report_service_meses import generar_reporte_meses
+
+
+class DummyRegistro:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class GenerarReporteMesesTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_reporte_excluye_marzo_en_detalle_y_frecuencia(self):
+        registros = [
+            DummyRegistro(
+                id_adolescente=1,
+                Nombre='Ana',
+                Apellido='García',
+                DNI='123',
+                Sede='Centro',
+                Actividad='Arte',
+                estado=2,
+                updated_at=datetime(2024, 5, 1),
+                enero=1,
+                marzo=1,
+                abril=1
+            ),
+            DummyRegistro(
+                id_adolescente=1,
+                Nombre='Ana',
+                Apellido='García',
+                DNI='123',
+                Sede='Centro',
+                Actividad='Arte',
+                estado=2,
+                updated_at=datetime(2024, 7, 1),
+                febrero=1,
+                marzo=1,
+                noviembre=1
+            ),
+            DummyRegistro(
+                id_adolescente=2,
+                Nombre='Luis',
+                Apellido='Pérez',
+                DNI='456',
+                Sede='Norte',
+                Actividad='Deporte',
+                estado=2,
+                updated_at=datetime(2024, 3, 1),
+                marzo=1
+            ),
+            DummyRegistro(
+                id_adolescente=3,
+                Nombre='Eva',
+                Apellido='López',
+                DNI='789',
+                Sede='Sur',
+                Actividad='Música',
+                estado=1,
+                updated_at=datetime(2024, 6, 1),
+                abril=1
+            )
+        ]
+
+        documents_dir = self.temp_dir.name
+
+        class FakeReportService:
+            @staticmethod
+            def get_vista_oferta_reconstruida(_db):
+                return registros
+
+        original_expanduser = os.path.expanduser
+
+        with patch('services.report_service_meses._get_report_service', return_value=FakeReportService), \
+             patch('services.report_service_meses.os.path.expanduser',
+                   side_effect=lambda path: documents_dir if path == '~/Documents' else original_expanduser(path)):
+            output_path = generar_reporte_meses(None, filename='reporte_prueba.xlsx')
+
+        self.assertTrue(os.path.exists(output_path))
+
+        libro = pd.ExcelFile(output_path)
+        detalle = pd.read_excel(libro, 'Meses_por_adolescente')
+        frecuencia = pd.read_excel(libro, 'Frecuencia_por_meses')
+
+        detalle_por_id = detalle.set_index('id_adolescente')
+
+        self.assertEqual(detalle_por_id.loc[1, 'cantidad_meses_sin_marzo'], 2)
+        self.assertEqual(detalle_por_id.loc[1, 'meses_asistidos_sin_marzo'], 'febrero - noviembre')
+        self.assertEqual(detalle_por_id.loc[2, 'cantidad_meses_sin_marzo'], 0)
+        valor_meses_id2 = detalle_por_id.loc[2, 'meses_asistidos_sin_marzo']
+        self.assertTrue(pd.isna(valor_meses_id2) or valor_meses_id2 == '')
+
+        self.assertNotIn('marzo', ''.join(detalle['meses_asistidos_sin_marzo'].dropna()))
+
+        frecuencia_por_cantidad = frecuencia.set_index('cantidad_meses_sin_marzo')['frecuencia'].to_dict()
+        self.assertEqual(frecuencia_por_cantidad.get(2), 1)
+        self.assertEqual(frecuencia_por_cantidad.get(0), 1)
+        self.assertEqual(len(frecuencia_por_cantidad), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a dedicated service to export a months-per-adolescent report that omits March and deduplicates by the latest update
- expose the new report generator through the services package with lazy imports to avoid eager database configuration
- cover the new functionality with a regression test that verifies March is excluded from both the detail and frequency worksheets

## Testing
- python -m unittest test_report_service_meses.py

------
https://chatgpt.com/codex/tasks/task_e_68d6cfb1da508328b821511f140ea9c5

## Summary by Sourcery

Generate monthly attendance Excel reports excluding March with record deduplication, register the generator via lazy-loaded service import, and validate functionality with a regression test

New Features:
- Introduce a new report generator function 'generar_reporte_meses' to export monthly attendance reports excluding March and deduplicate records by the latest update

Enhancements:
- Expose the new report generator through the services package using lazy imports to defer database configuration

Tests:
- Add a regression test to ensure March is excluded and deduplication logic applies in both detail and frequency worksheets