### PR TITLE
Cambiar selección de registro a más antiguo en reporte mensual

### DIFF
--- a/services/report_service_meses.py
+++ b/services/report_service_meses.py
@@ -12,11 +12,11 @@ MESES_SIN_MARZO: List[str] = [
 ]
 
 
-def _obtener_registro_mas_reciente(registro_actual, registro_existente):
-    """Devuelve el registro con el updated_at más reciente."""
-    fecha_actual = getattr(registro_actual, 'updated_at', None) or datetime.min
-    fecha_existente = getattr(registro_existente, 'updated_at', None) or datetime.min
-    return registro_actual if fecha_actual >= fecha_existente else registro_existente
+def _obtener_registro_mas_antiguo(registro_actual, registro_existente):
+    """Devuelve el registro con el updated_at más antiguo."""
+    fecha_actual = getattr(registro_actual, 'updated_at', None) or datetime.max
+    fecha_existente = getattr(registro_existente, 'updated_at', None) or datetime.max
+    return registro_actual if fecha_actual <= fecha_existente else registro_existente
 
 
 def _get_report_service():
@@ -37,7 +37,7 @@ def generar_reporte_meses(db: Session, filename: str = "reporte_meses.xlsx") -> 
         if existente is None:
             registros_por_adolescente[registro.id_adolescente] = registro
         else:
-            registros_por_adolescente[registro.id_adolescente] = _obtener_registro_mas_reciente(
+            registros_por_adolescente[registro.id_adolescente] = _obtener_registro_mas_antiguo(
                 registro,
                 existente
             )


### PR DESCRIPTION
## Summary
- actualizar la función auxiliar para elegir el registro más antiguo según updated_at
- ajustar el nombre de la función y su uso en la generación del reporte mensual

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d706c180388328943adb517cdf3054