### PR TITLE
Consolidar meses asistidos en reporte mensual

### DIFF
--- a/test_report_service_meses.py
+++ b/test_report_service_meses.py
@@ -97,7 +97,7 @@ class GenerarReporteMesesTests(unittest.TestCase):
         detalle_por_id = detalle.set_index('id_adolescente')
 
         self.assertEqual(detalle_por_id.loc[1, 'cantidad_meses_sin_marzo'], 2)
-        self.assertEqual(detalle_por_id.loc[1, 'meses_asistidos_sin_marzo'], 'febrero - noviembre')
+        self.assertEqual(detalle_por_id.loc[1, 'meses_asistidos_sin_marzo'], 'abril - noviembre')
         self.assertEqual(detalle_por_id.loc[2, 'cantidad_meses_sin_marzo'], 0)
         valor_meses_id2 = detalle_por_id.loc[2, 'meses_asistidos_sin_marzo']
         self.assertTrue(pd.isna(valor_meses_id2) or valor_meses_id2 == '')


### PR DESCRIPTION
## Summary
- reemplazar la constante de meses por CAMPOS_MESES y normalizar los valores con _to_bit
- consolidar la asistencia mensual por adolescente combinando registros y conservando los datos más recientes
- actualizar la generación del reporte y las pruebas para reflejar la nueva lógica

## Testing
- PYTHONPATH=. pytest test_report_service_meses.py

------
https://chatgpt.com/codex/tasks/task_e_68dbfd56be888328a5a49a7633142c68

## Summary by Sourcery

Consolidate monthly attendance per adolescent by normalizing values, merging multiple records into a single overview retaining the most recent data, refactor the report generation to use the new consolidation function, and update tests to match the adjusted month aggregation.

New Features:
- Add _to_bit helper to normalize month attendance values to binary
- Introduce consolidar_por_adolescente to aggregate attendance across multiple records per adolescent and preserve the latest metadata

Enhancements:
- Replace MESES_SIN_MARZO with CAMPOS_MESES constant for month fields
- Simplify generar_reporte_meses by delegating record consolidation to consolidar_por_adolescente

Tests:
- Update test expectations for meses_asistidos_sin_marzo to reflect the new consolidation logic